### PR TITLE
Fix repository id type mismatch

### DIFF
--- a/src/main/java/com/easyspeak/dev/repository/UserRepository.java
+++ b/src/main/java/com/easyspeak/dev/repository/UserRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Integer> {
+public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 }


### PR DESCRIPTION
## Summary
- fix UserRepository generic ID type

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683fe847f68883258e69e97db88f1b79